### PR TITLE
Update last check timestamp in state watcher

### DIFF
--- a/events/rancher_state_watcher.go
+++ b/events/rancher_state_watcher.go
@@ -188,6 +188,7 @@ func monitorHealth(healthCheckChannel <-chan fsnotify.Event, failedCheck chan<- 
 		lastCheck := time.Now()
 		select {
 		case <-healthCheckChannel:
+			lastCheck = time.Now()
 		case <-timer.C:
 			now := time.Now()
 			sinceLastCheck := now.Sub(lastCheck)


### PR DESCRIPTION
Hi,

I'm seeing the following pattern of modification times in an agent container, v0.7.9:

    -rw-r--r-- 1 root root    0 2015-06-10 23:01:26.125525713 +0000 .healthcheck
    -rw-r--r-- 1 root root    0 2015-06-10 23:01:34.127525840 +0000 .healthcheck
    -rw-r--r-- 1 root root    0 2015-06-10 23:01:36.126525872 +0000 .healthcheck

The logs show that the state watcher process has to restart constantly (only one cycle is shown below):

    time="2015-06-10T23:01:26Z" level="info" msg="Starting event router."
    time="2015-06-10T23:01:26Z" level="info" msg="Watching state directory: /var/lib/rancher/state/containers"
    time="2015-06-10T23:01:26Z" level="info" msg="Processing event: &docker.APIEvents{Status:\"start\", ID:\"c467f40211d7b84438eef729a9108e12ff9f5652b2151a880c92db6e74a6c68e\", From:\"-simulated-\", Time:0}"
    time="2015-06-10T23:01:26Z" level="info" msg="Processing event: &docker.APIEvents{Status:\"start\", ID:\"94a93af165f867f7694aacb0c6ee0a15009c708814c224fa5f938473a909a065\", From:\"-simulated-\", Time:0}"
    time="2015-06-10T23:01:26Z" level="info" msg="Processing event: &docker.APIEvents{Status:\"start\", ID:\"ac8409e03067f67903f75a05065068fc97537faa2c36d37155af48b00e70240c\", From:\"-simulated-\", Time:0}"
    time="2015-06-10T23:01:26Z" level="info" msg="Assigning IP [10.42.26.10/16], ContainerId [c467f40211d7b84438eef729a9108e12ff9f5652b2151a880c92db6e74a6c68e], Pid [6479]"
    time="2015-06-10T23:01:26Z" level="info" msg="Assigning IP [10.42.30.149/16], ContainerId [94a93af165f867f7694aacb0c6ee0a15009c708814c224fa5f938473a909a065], Pid [4854]"
    time="2015-06-10T23:01:36Z" level="warning" msg="Rancher state watcher returned with error. Waiting 0 and then restarting. Error that caused exit: Failed health check."
    time="2015-06-10T23:01:46Z" level="warning" msg="Rancher state watcher returned with error. Waiting 2 and then restarting. Error that caused exit: Failed health check."
    time="2015-06-10T23:01:58Z" level="warning" msg="Rancher state watcher returned with error. Waiting 4 and then restarting. Error that caused exit: Failed health check."
    time="2015-06-10T23:02:12Z" level="warning" msg="Rancher state watcher returned with error. Waiting 8 and then restarting. Error that caused exit: Failed health check."
    time="2015-06-10T23:02:30Z" level="warning" msg="Rancher state watcher returned with error. Waiting 16 and then restarting. Error that caused exit: Failed health check."

It seems that even though ```.healthcheck``` gets written at the start and every 8 seconds as expected, the 10 seconds timer still fires and reports an error condition.